### PR TITLE
Latest nn helpers in use at Dropbox

### DIFF
--- a/test_nn.cpp
+++ b/test_nn.cpp
@@ -15,13 +15,16 @@
  */
 
 #include "nn.hpp"
+#include <unordered_set>
 
 using namespace dropbox::oxygen;
 using std::shared_ptr;
 using std::unique_ptr;
+using std::unordered_set;
 
 struct pt_base { virtual ~pt_base() {} };
 struct pt : pt_base { int x; int y; pt(int x, int y) : x(x), y(y) {} };
+struct pt_other : pt_base { int x; int y; pt_other(int x, int y) : x(x), y(y) {} };
 
 void take_nn_unique_ptr(nn<unique_ptr<int>>) { }
 void take_nn_unique_ptr_constref(const nn<unique_ptr<int>> &) { }
@@ -105,6 +108,28 @@ int main() {
     b2 = p2;
     take_base_ptr(nn_make_unique<pt>(pt { 2, 2 }));
 
+    // Check nn_shared_ptr cast helpers: static cast to derived class
+    nn<shared_ptr<pt_base>> bd1 = nn_make_shared<pt>(3, 4);
+    nn<shared_ptr<pt>> ds1 = nn_static_pointer_cast<pt>(bd1);
+    assert(ds1->x == 3);
+    assert(ds1->y == 4);
+
+    // Check nn_shared_ptr cast helpers: dynamic cast to derived class
+    shared_ptr<pt> dd1 = nn_dynamic_pointer_cast<pt>(bd1);
+    assert(dd1);
+    assert(dd1->x == 3);
+    assert(dd1->y == 4);
+    shared_ptr<pt_other> dd_other = nn_dynamic_pointer_cast<pt_other>(bd1);
+    assert(!dd_other);
+
+    // Check nn_shared_ptr cast helpers: const cast
+    nn_shared_ptr<pt> ncp1 = nn_make_shared<pt>(3, 4);
+    nn_shared_ptr<const pt> cp1 = nn_make_shared<pt>(3, 4);
+    nn_shared_ptr<pt> ncp2 = nn_const_pointer_cast<pt>(cp1);
+    ncp2->x = 11;
+    assert(cp1->x == 11);
+    assert(cp1->y == 4);
+
     // Check construction of smart pointers from raw pointers
     int * raw1 = new int(7);
     nn<int*> raw2 = NN_CHECK_ASSERT(new int(7));
@@ -121,6 +146,14 @@ int main() {
     assert(u1 != u2);
     assert(u1 > u2 || u1 < u2);
     assert(u1 >= u2 || u1 <= u2);
+
+    // Test hashing
+    unordered_set<nn_shared_ptr<pt>> sset;
+    sset.emplace(nn_make_shared<pt>(1, 2));
+    unordered_set<nn_unique_ptr<pt>> uset;
+    uset.emplace(nn_make_unique<pt>(1, 2));
+    unordered_set<nn<pt*>> rset;
+    rset.emplace(NN_CHECK_ASSERT(new pt(1, 2)));
 
     nn<shared_ptr<int>> shared = move(u2);
 


### PR DESCRIPTION
Latest nn helpers in use at Dropbox:
- std::hash implementation for nn
- Casting functions for nn_shared_ptr
- static_assert to avoid nn<nn<T>>

@j4cbo your review would be appreciated.