### PR TITLE
Add pass-through support for the std::shared_ptr aliasing constructor.

### DIFF
--- a/nn.hpp
+++ b/nn.hpp
@@ -140,6 +140,15 @@ public:
     // "base_ptr = derived_ptr;" will run the type-converting constructor followed by the
     // implicit move assignment operator.
 
+    // Two-argument constructor, designed for use with the shared_ptr aliasing constructor.
+    // This will not be instantiated if PtrType doesn't have a suitable constructor.
+    template <typename OtherType,
+              typename std::enable_if<
+                    std::is_constructible<PtrType, OtherType, element_type *>::value
+                , int>::type = 0>
+    nn(const nn<OtherType> & ownership_ptr, nn<element_type *> target_ptr)
+        : ptr(ownership_ptr.operator const OtherType & (), target_ptr) {}
+
     // Comparisons. Other comparisons are implemented in terms of these.
     template <typename L, typename R>
     friend bool operator==(const nn<L> &, const R &);

--- a/test_nn.cpp
+++ b/test_nn.cpp
@@ -188,5 +188,9 @@ int main() {
     // Ensure namespace_test code is run, and not unused.
     namespace_test();
 
+    // Check aliasing constructor
+    auto set_ptr = nn_make_shared<unordered_set<int>>(unordered_set<int>{42});
+    nn_shared_ptr<const int> set_element_ptr(set_ptr, nn_addr(*set_ptr->begin()));
+
     return 0;
 }


### PR DESCRIPTION
Fixes #3.