### PR TITLE
Cleanups after integrating prior PR

### DIFF
--- a/nn.hpp
+++ b/nn.hpp
@@ -231,7 +231,7 @@ public:
         return nn_shared_ptr<T>(i_promise_i_checked_for_null, this->shared_from_this());
     }
     nn_shared_ptr<const T> nn_shared_from_this() const {
-        return nn_shared_ptr<T>(i_promise_i_checked_for_null, this->shared_from_this());
+        return nn_shared_ptr<const T>(i_promise_i_checked_for_null, this->shared_from_this());
     }
 };
 

--- a/test_nn.cpp
+++ b/test_nn.cpp
@@ -22,6 +22,7 @@
 static void namespace_test() {
     dropbox::oxygen::nn<int*> t0 = NN_CHECK_ASSERT(new int(111));
     dropbox::oxygen::nn<int*> t1 = NN_CHECK_THROW(new int(222));
+    (void)t0; (void)t1;
 }
 
 using namespace dropbox::oxygen;


### PR DESCRIPTION
- Add missing const in nn_shared_from_this()
- Suppress unused variable warnings